### PR TITLE
Depend on Mox 0.5.0 which supports and.callThrough

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,5 +11,8 @@
     "angular-loader": "~1.4.0",
     "angular-mocks": "~1.4.0",
     "html5-boilerplate": "~5.2.0"
+  },
+  "devDependencies": {
+    "mox": "~0.5.0"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,9 +7,10 @@ module.exports = function(config){
       'app/bower_components/angular/angular.js',
       'app/bower_components/angular-route/angular-route.js',
       'app/bower_components/angular-mocks/angular-mocks.js',
+      'app/bower_components/mox/dist/mox.js',
       'app/components/**/*.js',
       'app/view*/**/*.js',
-      'specs/**/*.js'
+      'specs/*.js'
 
     ],
 

--- a/specs/callThroughSpec.js
+++ b/specs/callThroughSpec.js
@@ -28,7 +28,7 @@ describe("testing mox spies", function () {
                 expect(num).toBe('fakeReturn');
             });
             it("should be able to call through from the spy", function () {
-                //THIS TEST FAILS!
+                //THIS TEST FAILS! (not anymore with mox 0.5.0)
                 moxTestService.addOne.and.callThrough();
                 var num = 1;
                 num = moxTestService.addOne(num, "This should also print to the console and increment value, should call the spy AND the real function");


### PR DESCRIPTION
Mox 0.5.0 supports and.callThrough, so this test project has no failing tests anymore.
